### PR TITLE
making the base path configurable

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ var through2 = require('through2'),
       'package.json': {cmd: 'npm', args: ['install']}
     };
 
-module.exports = exports = function install () {
+module.exports = exports = function install (basepath) {
   var toRun = [],
       count = 0;
 
@@ -40,7 +40,7 @@ module.exports = exports = function install () {
               gutil.log(err.message, 'Run `' + gutil.colors.yellow(formatCommand(command)) + '` manually');
             }
             done(cb, toRun.length);
-          });
+          }, basepath);
         });
       }
     }

--- a/lib/commandRunner.js
+++ b/lib/commandRunner.js
@@ -1,14 +1,13 @@
-
 var which = require('which'),
     childProcess = require('child_process');
 
-exports.run = function run (command, cb) {
+exports.run = function run (command, cb, basepath) {
   which(command.cmd, function(err, cmdpath){
     if (err) {
       cb(new Error('Can\'t install.'));
       return;
     }
-    var cmd = childProcess.spawn(cmdpath, command.args, {stdio: 'inherit', cwd: process.cwd()});
+    var cmd = childProcess.spawn(cmdpath, command.args, {stdio: 'inherit', cwd: basepath || process.cwd()});
     cmd.on('close', function () {
       cb();
     });


### PR DESCRIPTION
Hi, 

i find it very convenient in my slush generators to create the target directory of new slush generated projects inside the generator itself. Otherwise many people (for example me ;)) are ending up generating content in a project base repository and not in the targeted new project specific one.

To accomplish this i added an optional parameter for the basepath, which can be used instead of the cwd. I hope you'll find this helpful too.

As a little side note. I was not able to run the tests successfully on my machine, do you have any hints there?

Thanks in advance, Falk
