### PR TITLE
Added ignoreScripts modifier for npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,27 @@ var install = require("gulp-install");
 
 gulp.src(__dirname + '/templates/**')
   .pipe(gulp.dest('./'))
-  .pipe(install({production: true}));
+  .pipe(install({production: true}));  
 ```
+
+### options.ignoreScripts
+
+**Type:** `Boolean`
+
+**Default:** `false`
+
+
+Set to `true` if `npm install` should be appended with the `--ignore-scripts` parameter when stream contains `package.json`. Useful for skipping `postinstall` scripts with `npm`. 
+
+**Example:**
+
+```javascript
+var install = require("gulp-install");
+
+gulp.src(__dirname + '/templates/**')
+  .pipe(gulp.dest('./'))
+  .pipe(install({ignoreScripts: true}));
+```  
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -21,17 +21,26 @@ module.exports = exports = function install (opts) {
       }
       var cmd = clone(cmdMap[path.basename(file.path)]);
 
-          console.log(cmd, opts);
 
+          
 
       if (cmd) {
+
+
+        var cmdArgs = []; 
+
+
         if(opts && opts.production) {
-          cmd.args.push('--production');
+          //cmd.args.push('--production');
         }
 
         if(opts && opts.ignoreScripts) {
-          cmd.args.push('--ignore-scripts');
+          //cmd.args.push('--ignore-scripts');
         }
+
+        cmd.args.concat(cmdArgs);
+
+        console.log(cmd);
 
         cmd.cwd = path.dirname(file.path);
         toRun.push(cmd);

--- a/index.js
+++ b/index.js
@@ -1,56 +1,50 @@
 'use strict';
 var through2 = require('through2'),
-    gutil = require('gulp-util'),
-    path = require('path'),
-    commandRunner = require('./lib/' + (isTest() ? 'test_' : '') + 'commandRunner'),
-    cmdMap = {
-      'tsd.json': {cmd: 'tsd', args: ['reinstall', '--save']},
-      'bower.json': {cmd: 'bower', args: ['install', '--config.interactive=false']},
-      'package.json': {cmd: 'npm', args: ['install']}
-    };
+  gutil = require('gulp-util'),
+  path = require('path'),
+  commandRunner = require('./lib/' + (isTest() ? 'test_' : '') + 'commandRunner'),
+  cmdMap = {
+    'tsd.json': {
+      cmd: 'tsd',
+      args: ['reinstall', '--save']
+    },
+    'bower.json': {
+      cmd: 'bower',
+      args: ['install', '--config.interactive=false']
+    },
+    'package.json': {
+      cmd: 'npm',
+      args: ['install']
+    }
+  };
 
-module.exports = exports = function install (opts) {
+module.exports = exports = function install(opts) {
   var toRun = [],
-      count = 0;
+    count = 0;
 
-  return through2(
-    {objectMode: true},
-    function (file, enc, cb) {
+  return through2({
+      objectMode: true
+    },
+    function(file, enc, cb) {
       if (!file.path) {
         cb();
       }
       var cmd = clone(cmdMap[path.basename(file.path)]);
 
-
-          
-
       if (cmd) {
-
-
-        var cmdArgs = []; 
-
-
-        if(opts && opts.production) {
-          //cmd.args.push('--production');
+        if (opts && opts.production) {
+          cmd.args.push('--production');
         }
-
-        if(opts && opts.ignoreScripts) {
-          //cmd.args.push('--ignore-scripts');
+        if (opts && opts.ignoreScripts) {
+          cmd.args.push('--ignore-scripts');
         }
-
-        cmd.args.concat(cmdArgs);
-
-        console.log(cmd);
-
         cmd.cwd = path.dirname(file.path);
         toRun.push(cmd);
       }
-      console.log(toRun, file);
-
       this.push(file);
       cb();
     },
-    function (cb) {
+    function(cb) {
       if (!toRun.length) {
         return cb();
       }
@@ -58,8 +52,8 @@ module.exports = exports = function install (opts) {
         log('Skipping install.', 'Run `' + gutil.colors.yellow(formatCommands(toRun)) + '` manually');
         return cb();
       } else {
-        toRun.forEach(function (command) {
-          commandRunner.run(command, function (err) {
+        toRun.forEach(function(command) {
+          commandRunner.run(command, function(err) {
             if (err) {
               log(err.message, 'Run `' + gutil.colors.yellow(formatCommand(command)) + '` manually');
             }
@@ -70,42 +64,42 @@ module.exports = exports = function install (opts) {
     }
   );
 
-  function done (cb, length) {
+  function done(cb, length) {
     if (++count === length) {
       cb();
     }
   }
 };
 
-function log () {
+function log() {
   if (isTest()) {
     return;
   }
   gutil.log.apply(gutil, [].slice.call(arguments));
 }
 
-function formatCommands (cmds) {
+function formatCommands(cmds) {
   return cmds.map(formatCommand).join(' && ');
 }
 
-function formatCommand (command) {
+function formatCommand(command) {
   return command.cmd + ' ' + command.args.join(' ');
 }
 
-function skipInstall () {
+function skipInstall() {
   return process.argv.slice(2).indexOf('--skip-install') >= 0;
 }
 
-function isTest () {
+function isTest() {
   return process.env.NODE_ENV === 'test';
 }
 
-function clone (obj) {
+function clone(obj) {
   if (Array.isArray(obj)) {
     return obj.map(clone);
   } else if (typeof obj === 'object') {
     var copy = {};
-    Object.keys(obj).forEach(function (key) {
+    Object.keys(obj).forEach(function(key) {
       copy[key] = clone(obj[key]);
     });
     return copy;

--- a/index.js
+++ b/index.js
@@ -33,6 +33,8 @@ module.exports = exports = function install (opts) {
         cmd.cwd = path.dirname(file.path);
         toRun.push(cmd);
       }
+      console.log(toRun, file);
+      
       this.push(file);
       cb();
     },

--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ module.exports = exports = function install (opts) {
         }
 
         if(opts && opts.ignoreScripts) {
+          console.log(opts);
           cmd.args.push('--ignore-scripts');
         }
 
@@ -34,7 +35,7 @@ module.exports = exports = function install (opts) {
         toRun.push(cmd);
       }
       console.log(toRun, file);
-      
+
       this.push(file);
       cb();
     },

--- a/index.js
+++ b/index.js
@@ -26,6 +26,10 @@ module.exports = exports = function install (opts) {
           cmd.args.push('--production');
         }
 
+        if(opts && opts.ignoreScripts) {
+          cmd.args.push('--ignore-scripts');
+        }
+
         cmd.cwd = path.dirname(file.path);
         toRun.push(cmd);
       }

--- a/index.js
+++ b/index.js
@@ -21,13 +21,15 @@ module.exports = exports = function install (opts) {
       }
       var cmd = clone(cmdMap[path.basename(file.path)]);
 
+          console.log(cmd, opts);
+
+
       if (cmd) {
         if(opts && opts.production) {
           cmd.args.push('--production');
         }
 
         if(opts && opts.ignoreScripts) {
-          console.log(opts);
           cmd.args.push('--ignore-scripts');
         }
 

--- a/test/install_test.js
+++ b/test/install_test.js
@@ -78,6 +78,31 @@ describe('gulp-install', function () {
     stream.end();
   });
 
+  it('should run `npm install --ignore-scripts` if stream contains `package.json` and `ignoreScripts` option is set', function (done) {
+    var file = fixture('package.json');
+
+    var stream = install({ignoreScripts:true});
+
+    stream.on('error', function(err) {
+      should.exist(err);
+      done(err);
+    });
+
+    stream.on('data', function () {
+    });
+
+    stream.on('end', function () {
+      commandRunner.commandsThatHasRun.length.should.equal(1);
+      commandRunner.commandsThatHasRun[0].cmd.should.equal('npm');
+      commandRunner.commandsThatHasRun[0].args.should.eql(['install', '--ignore-scripts']);
+      done();
+    });
+
+    stream.write(file);
+
+    stream.end();
+  });
+
 
   it('should run `bower install --config.interactive=false` if stream contains `bower.json`', function (done) {
     var file = fixture('bower.json');


### PR DESCRIPTION
I added another CLI option for npm with required tests etc for the `--ignore-scripts` argument. Apologies for the reformatting of the JS, feel free to reject if you'd like me to revert to your formatting, this is what Sublime autoformatted it as. 