### PR TITLE
Pip support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,12 @@
 
 > Automatically install npm, bower, tsd, and pip packages/dependencies if the relative configurations are found in the gulp file stream respectively
 
-File Found | Command run 
-`package.json` | `npm install`
-`bower.json` | `bower install`
-`tsd.json` | `tsd install`
-`requirements.txt` | `pip install -r requirements.txt`
+| File Found | Command run|  
+| --- | --- |  
+|`package.json` | `npm install`|  
+|`bower.json` | `bower install`|  
+|`tsd.json` | `tsd install`|  
+|`requirements.txt` | `pip install -r requirements.txt`|  
 
 It will run the command in the directory it finds the file, so if you have configs nested in a lower directory than your `slushfile.js`/`gulpfile.js`, this will still work. 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # gulp-install [![NPM version][npm-image]][npm-url] [![Build Status][travis-image]][travis-url] [![Dependency Status][depstat-image]][depstat-url]
 
-> Automatically install npm and bower packages if package.json or bower.json is found in the gulp file stream respectively
+> Automatically install npm, bower, tsd, and pip packages/dependencies if the relative configurations are found in the gulp file stream respectively
+
+File Found | Command run 
+`package.json` | `npm install`
+`bower.json` | `bower install`
+`tsd.json` | `tsd install`
+`requirements.txt` | `pip install -r requirements.txt`
+
+It will run the command in the directory it finds the file, so if you have configs nested in a lower directory than your `slushfile.js`/`gulpfile.js`, this will still work. 
 
 ## Primary objective
 
@@ -86,6 +94,7 @@ gulp.src(__dirname + '/templates/**')
   .pipe(gulp.dest('./'))
   .pipe(install({ignoreScripts: true}));
 ```  
+
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -15,6 +15,10 @@ var through2 = require('through2'),
     'package.json': {
       cmd: 'npm',
       args: ['install']
+    },
+    'requirements.txt': {
+      cmd: 'pip',
+      args: ['install', '-r', 'requirements.txt']
     }
   };
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gulp-install",
   "version": "0.4.0",
-  "description": "Automatically install npm and bower packages if package.json or bower.json is found in the gulp file stream respectively",
+  "description": "Automatically install npm, bower, tsd, and pip packages/dependencies if the relative configurations are found in the gulp file stream respectively",
   "main": "index.js",
   "scripts": {
     "test": "NODE_ENV=test mocha -R spec"

--- a/test/install_test.js
+++ b/test/install_test.js
@@ -251,6 +251,32 @@ describe('gulp-install', function () {
 
   });
 
+  it('should run `pip install -r requirements.txt` if stream contains `requirements.txt`', function (done) {
+    var file = fixture('requirements.txt');
+
+    var stream = install();
+
+    stream.on('error', function (err) {
+      should.exist(err);
+      done(err);
+    });
+
+    stream.on('data', function () {
+    });
+
+    stream.on('end', function () {
+      commandRunner.run.called.should.equal(1);
+      commandRunner.run.commands[0].cmd.should.equal('pip');
+      commandRunner.run.commands[0].args.should.eql(['install', '-r', 'requirements.txt']);
+      done();
+    });
+
+    stream.write(file);
+
+    stream.end();
+
+  });
+
   it('should not run any installs when `--skip-install` CLI option is provided', function (done) {
     var newArgs = args.slice();
     newArgs.push('--skip-install');


### PR DESCRIPTION
As someone who stumbled across your module and wanted support for pip, as well as someone who was slightly confused on how this works, I'm requesting a few changes in this pull request. 

1. Updated README - these updates were to provide clarity on the cwd nesting, as well as add a table that says exactly what files are supported and what the resulting commands will be.  Just makes it more readable (IMHO) as a new user of the module. 

2. Added support for pip - Even though pip requires a `-r` flag to specify what the requirements file is, other deployment systems (like Docker) look for the existence of this file to run `pip install` on it. These changes add support for pip as well. 