### PR TITLE
Added jspm install feature

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,10 @@ var through2 = require('through2'),
     'package.json': {
       cmd: 'npm',
       args: ['install']
+    },
+    'config.js': {
+      cmd: 'jspm',
+      args: ['install']
     }
   };
 

--- a/test/install_test.js
+++ b/test/install_test.js
@@ -251,6 +251,31 @@ describe('gulp-install', function () {
 
   });
 
+  it('should run `jspm install` if stream contains `config.js`', function (done) {
+    var file = fixture('config.js');
+
+    var stream = install();
+
+    stream.on('error', function(err) {
+      should.exist(err);
+      done(err);
+    });
+
+    stream.on('data', function () {
+    });
+
+    stream.on('end', function () {
+      commandRunner.run.called.should.equal(1);
+      commandRunner.run.commands[0].cmd.should.equal('jspm');
+      commandRunner.run.commands[0].args.should.eql(['install']);
+      done();
+    });
+
+    stream.write(file);
+
+    stream.end();
+  });
+
   it('should not run any installs when `--skip-install` CLI option is provided', function (done) {
     var newArgs = args.slice();
     newArgs.push('--skip-install');


### PR DESCRIPTION
- manual test and new spec passing 
- using config.js to decide if jspm install should execute. this is a bit weird since 1) it's a js file, 2) it's actually related to System.js instead. should I be looking for a jspm property in the package.json file instead ? jspm itself seems to want a config.js file however. 