### PR TITLE
Add support for generic args option

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,27 @@ gulp.src(__dirname + '/templates/**')
   .pipe(install({allowRoot: true}));  
 ```
 
+### options.args
+
+**Type:** `Array or String`
+
+**Default:** `undefined`
+
+
+Specify additional arguments that will be passed to the install command(s).
+
+**Example:**
+
+```javascript
+var install = require("gulp-install");
+
+gulp.src(__dirname + '/templates/**')
+  .pipe(gulp.dest('./'))
+  .pipe(install({
+      args: ['dev', '--no-shrinkwrap' ]} // npm install --dev --no-shrinkwrap
+    ));  
+```
+
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -42,6 +42,11 @@ module.exports = exports = function install(opts) {
         if (opts && opts.ignoreScripts) {
           cmd.args.push('--ignore-scripts');
         }
+        if (opts && opts.args) {
+          formatArguments(opts.args).forEach(function(arg) {
+            cmd.args.push(arg);
+          });
+        }
         if (cmd.cmd === 'bower' && opts && opts.allowRoot) {
           cmd.args.push('--allow-root');
         }
@@ -96,6 +101,28 @@ function formatCommands(cmds) {
 
 function formatCommand(command) {
   return command.cmd + ' ' + command.args.join(' ');
+}
+
+function formatArguments(args) {
+  if (Array.isArray(args)) {
+    args.forEach(function(arg, index, arr) {
+      arr[index] = formatArgument(arg);
+    });
+    return args;
+  } else if (typeof args === 'string' || args instanceof String) {
+    return [ formatArgument(args) ];
+  } else {
+    log('Arguments are not passed in a valid format: ' + args);
+    return [];
+  }
+}
+
+function formatArgument(arg) {
+  var result = arg;
+  while (!result.match(/--.*/)) {
+    result = '-' + result;
+  }
+  return result;
 }
 
 function skipInstall() {

--- a/test/install_test.js
+++ b/test/install_test.js
@@ -334,6 +334,99 @@ describe('gulp-install', function () {
     stream.end();
   });
 
+  it('should run `npm install --dev --no-shrinkwrap` if args option is the appropriate array', function(done) {
+    var files = [
+      fixture('package.json')
+    ];
+
+    var stream = install({
+        args: ['dev', 'no-shrinkwrap']
+      });
+
+    stream.on('error', function(err) {
+      should.exist(err);
+      done(err);
+    });
+
+    stream.on('data', function () {
+    });
+
+    stream.on('end', function () {
+      commandRunner.run.called.should.equal(1);
+      commandRunner.run.commands[0].cmd.should.equal('npm');
+      commandRunner.run.commands[0].args.should.eql(['install', '--dev', '--no-shrinkwrap']);
+      done();
+    });
+
+    files.forEach(function (file) {
+      stream.write(file);
+    });
+
+    stream.end();
+  });
+
+  it('should run `npm install --dev` if args option is \'--dev\'', function(done) {
+    var files = [
+      fixture('package.json')
+    ];
+
+    var stream = install({
+        args: 'dev'
+      });
+
+    stream.on('error', function(err) {
+      should.exist(err);
+      done(err);
+    });
+
+    stream.on('data', function () {
+    });
+
+    stream.on('end', function () {
+      commandRunner.run.called.should.equal(1);
+      commandRunner.run.commands[0].cmd.should.equal('npm');
+      commandRunner.run.commands[0].args.should.eql(['install', '--dev']);
+      done();
+    });
+
+    files.forEach(function (file) {
+      stream.write(file);
+    });
+
+    stream.end();
+  });
+
+  it('should run `npm install` even if args option is in an invalid format', function(done) {
+    var files = [
+      fixture('package.json')
+    ];
+
+    var stream = install({
+        args: 42
+      });
+
+    stream.on('error', function(err) {
+      should.exist(err);
+      done(err);
+    });
+
+    stream.on('data', function () {
+    });
+
+    stream.on('end', function () {
+      commandRunner.run.called.should.equal(1);
+      commandRunner.run.commands[0].cmd.should.equal('npm');
+      commandRunner.run.commands[0].args.should.eql(['install']);
+      done();
+    });
+
+    files.forEach(function (file) {
+      stream.write(file);
+    });
+
+    stream.end();
+  });
+
   it('should not run any installs when `--skip-install` CLI option is provided', function (done) {
     var newArgs = args.slice();
     newArgs.push('--skip-install');


### PR DESCRIPTION
This commit adds a generic 'args' option to pass any supported parameter to npm install and resolves #28.