### PR TITLE
Add engines field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.1.0",
   "description": "Automatically install npm, bower, tsd, and pip packages/dependencies if the relative configurations are found in the gulp file stream respectively",
   "main": "index.js",
+  "engines": {
+    "node": ">=6"
+  },
   "scripts": {
     "test": "NODE_ENV=test mocha -R spec"
   },


### PR DESCRIPTION
I had a build failure and wasn't sure what the cause was--this will help inform the user if they have the engine-strict flag set in their config.

See https://docs.npmjs.com/files/package.json#engines