### PR TITLE
Use node_module/.bin as a fallback path for search

### DIFF
--- a/lib/command-runner.js
+++ b/lib/command-runner.js
@@ -1,20 +1,34 @@
 'use strict';
 const {spawn} = require('child_process');
+const {join} = require('path');
 const which = require('which');
+const fs = require('fs');
+const path = require('fs');
 
 exports.run = function (command) {
   return new Promise((resolve, reject) => {
     which(command.cmd, (err, cmdpath) => {
-      if (err) {
-        return reject(new Error(`Can't install! "${command.cmd}" doesn't seem to be installed.`));
+      next = function (cb, cmdpath) {
+        const cmd = spawn(quoteIfNecessary(cmdpath), command.args, {shell: true, stdio: 'inherit', cwd: command.cwd || process.cwd()});
+        cmd.on('close', code => {
+          if (code !== 0) {
+            return reject(new Error(`"${command.cmd}" exited with non-zero code ${code}`));
+          }
+          resolve();
+        });
       }
-      const cmd = spawn(quoteIfNecessary(cmdpath), command.args, {shell: true, stdio: 'inherit', cwd: command.cwd || process.cwd()});
-      cmd.on('close', code => {
-        if (code !== 0) {
-          return reject(new Error(`"${command.cmd}" exited with non-zero code ${code}`));
-        }
-        resolve();
-      });
+      if (err) {
+        var possible_node_module_location = path.join('node_modules','.bin', command.cmd);
+        fs.access(possible_node_module_location, fs.constants.X_OK, (err) => {
+          if (err) {
+            return reject(new Error(`Can't install! "${command.cmd}" doesn't seem to be installed.`));
+          } else {
+            next(cb, possible_node_module_location);
+          }
+        });
+      } else {
+        next(cb, cmdpath);
+      }
     });
   });
 };


### PR DESCRIPTION
When you want to have a clean package, you must put dev tool list and version in devDependencies in your package.json, for example :

  "devDependencies": {
    "gulp": "^3.8.8",
    "bower": "^1.8.0"
  }
However, node-which which is used to check if the binary is present doesn't check in this folder since ./node_modules/.bin/ is unlikely to be in your path.

Thid PR use `./node_modules/.bin` as a fallback path