### PR TITLE
Drop dependency on deprecated `gulp-util`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .DS_Store
 node_modules/
 temp/
+package-lock.json
+yarn.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
 .DS_Store
 node_modules/
 temp/
-package-lock.json
-yarn.lock

--- a/index.js
+++ b/index.js
@@ -2,7 +2,8 @@
 const path = require('path');
 const through2 = require('through2');
 const dargs = require('dargs');
-const gutil = require('gulp-util');
+const fancyLog = require('fancy-log');
+const chalk = require('chalk');
 const groupBy = require('lodash.groupby');
 const PQueue = require('p-queue');
 const commandRunner = require('./lib/command-runner');
@@ -85,7 +86,7 @@ module.exports = function (opts = {}, done = noop) {
         return cb();
       }
       if (skipInstall()) {
-        log('Skipping install.', 'Run `' + gutil.colors.yellow(formatCommands(toRun)) + '` manually');
+        log('Skipping install.', 'Run `' + chalk.yellow(formatCommands(toRun)) + '` manually');
         return cb();
       }
       const groupedCommands = groupBy(toRun, 'cmd');
@@ -103,7 +104,7 @@ module.exports = function (opts = {}, done = noop) {
 function logFailure(command) {
   return promise => {
     return promise.catch(err => {
-      log(err.message, ', run `' + gutil.colors.yellow(formatCommand(command)) + '` manually');
+      log(err.message, ', run `' + chalk.yellow(formatCommand(command)) + '` manually');
       throw err;
     });
   };
@@ -113,7 +114,7 @@ function log(...args) {
   if (isTest()) {
     return;
   }
-  gutil.log(...args);
+  fancyLog(...args);
 }
 
 function formatCommands(cmds) {

--- a/package.json
+++ b/package.json
@@ -23,8 +23,9 @@
   },
   "homepage": "https://github.com/slushjs/gulp-install",
   "dependencies": {
+    "chalk": "^2.3.0",
     "dargs": "^5.1.0",
-    "gulp-util": "^3.0.7",
+    "fancy-log": "^1.3.2",
     "lodash.groupby": "^4.6.0",
     "p-queue": "^1.0.0",
     "through2": "^2.0.3",
@@ -34,6 +35,7 @@
     "chai": "^3.2.0",
     "mocha": "^3.2.0",
     "standard-version": "^4.0.0",
+    "vinyl": "^2.1.0",
     "xo": "^0.18.0"
   },
   "xo": {

--- a/test/install-test.js
+++ b/test/install-test.js
@@ -3,7 +3,7 @@
 'use strict';
 const path = require('path');
 const chai = require('chai');
-const gutil = require('gulp-util');
+const Vinyl = require('vinyl');
 const commandRunner = require('../lib/command-runner');
 const install = require('../.');
 
@@ -12,7 +12,7 @@ const args = process.argv.slice();
 
 function fixture(file) {
   const filepath = path.join(__dirname, file);
-  return new gutil.File({
+  return new Vinyl({
     path: filepath,
     cwd: __dirname,
     base: path.join(__dirname, path.dirname(file)),


### PR DESCRIPTION
Closes slushjs/gulp-install#52