### PR TITLE
remove gutil and add compare ability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+<a name="1.1.0"></a>
+# [1.1.0](https://github.com/slushjs/gulp-install/compare/v1.0.1...v1.1.0) (2017-03-23)
+
+
+### Features
+
+* add callback support (closes [#17](https://github.com/slushjs/gulp-install/issues/17) [#31](https://github.com/slushjs/gulp-install/issues/31)) ([2e58f84](https://github.com/slushjs/gulp-install/commit/2e58f84))
+
+
+
 <a name="1.0.1"></a>
 ## [1.0.1](https://github.com/slushjs/gulp-install/compare/v1.0.0...v1.0.1) (2017-03-23)
 

--- a/package.json
+++ b/package.json
@@ -23,8 +23,10 @@
   },
   "homepage": "https://github.com/slushjs/gulp-install",
   "dependencies": {
+    "chalk": "^2.3.0",
+    "fancy-log": "^1.3.2",
+    "vinyl": "^2.1.0",
     "dargs": "^5.1.0",
-    "gulp-util": "^3.0.7",
     "lodash.groupby": "^4.6.0",
     "p-queue": "^1.0.0",
     "through2": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-install",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Automatically install npm, bower, tsd, and pip packages/dependencies if the relative configurations are found in the gulp file stream respectively",
   "main": "index.js",
   "scripts": {
@@ -23,8 +23,9 @@
   },
   "homepage": "https://github.com/slushjs/gulp-install",
   "dependencies": {
+    "chalk": "^2.3.0",
+    "fancy-log": "^1.3.2",
     "dargs": "^5.1.0",
-    "gulp-util": "^3.0.7",
     "lodash.groupby": "^4.6.0",
     "p-queue": "^1.0.0",
     "through2": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "chalk": "^2.3.0",
     "fancy-log": "^1.3.2",
+    "vinyl": "^2.1.0",
     "dargs": "^5.1.0",
     "lodash.groupby": "^4.6.0",
     "p-queue": "^1.0.0",

--- a/test/install-test.js
+++ b/test/install-test.js
@@ -3,7 +3,7 @@
 'use strict';
 const path = require('path');
 const chai = require('chai');
-const gutil = require('gulp-util');
+const vinyl = require('vinyl');
 const commandRunner = require('../lib/command-runner');
 const install = require('../.');
 
@@ -12,7 +12,7 @@ const args = process.argv.slice();
 
 function fixture(file) {
   const filepath = path.join(__dirname, file);
-  return new gutil.File({
+  return new vinyl({
     path: filepath,
     cwd: __dirname,
     base: path.join(__dirname, path.dirname(file)),


### PR DESCRIPTION
Replace gulp-util with specific modules since gulp-util is now [depricated](https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5).

Creates temp directories that hold the last known version of the files, and compares them to the current version for changes.  This action is tied to a new option: `{compare: true}`